### PR TITLE
Add Nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1669556876,
+        "narHash": "sha256-WF1KAul1L/ALduSLj0FDrc3uP3ZAEm8jMVeW1J4efOY=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "9edd8bbef7b0136febfb6d1bdc41c9bc80c0f90f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "master",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,87 @@
+{
+  description = "A GTK Mastodon client, forked from the now-archived Tootle";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/master";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { system = system; };
+
+      nativeBuildInputs = with pkgs; [
+        meson
+        ninja
+        vala
+        pkg-config
+        desktop-file-utils
+        python39
+        gtk3
+        wrapGAppsHook
+      ];
+
+      buildInputs = with pkgs; [
+        meson
+        ninja
+        vala
+        glib
+        gtk4
+        json-glib
+        libxml2
+        libgee
+        libsoup
+        libadwaita
+        libsecret
+      ];
+    in
+    {
+      devShells = {
+        ${system} = {
+          default = pkgs.mkShell {
+            packages = buildInputs ++ nativeBuildInputs;
+          };
+        };
+      };
+
+      packages = {
+        ${system} = {
+          tooth =
+            pkgs.stdenv.mkDerivation {
+              name = "tooth";
+              src = self;
+
+              nativeBuildInputs = nativeBuildInputs;
+              buildInputs = buildInputs;
+
+              preFixup = with pkgs; ''
+                gappsWrapperArgs+=(
+                  --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS" \
+                  --prefix XDG_DATA_DIRS : "$out/share" \
+                  --prefix XDG_DATA_DIRS : "$out/share/gsettings-schemas/dev.geopjr.tooth" \
+                  --prefix XDG_DATA_DIRS : "${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}" \
+                  --prefix XDG_DATA_DIRS : "${hicolor-icon-theme}/share" \
+                  --prefix GI_TYPELIB_PATH : "${lib.makeSearchPath "lib/girepository-1.0" [ pango json-glib ]}"
+                )
+              '';
+
+              configurePhase = "meson build --prefix=$out";
+
+              buildPhase = "ninja -C build";
+              installPhase = "
+                patchShebangs meson/post_install.py
+                ninja -C build install
+              ";
+
+              postInstallPhase = "
+                meson/post_install.py
+              ";
+            };
+
+          default = self.packages.${system}.tooth;
+        };
+      };
+
+
+    };
+}


### PR DESCRIPTION
This PR adds a Nix flake, so that Tooth can be easily installed by people who use Nix as their package manager (i.e. NixOS users).

For example, to install this once the PR is merged:

```
nix profile install github:GeopJr/Tooth
```

It uses all the existing build tooling, and installs cleanly on a Nix machine.

Hope you don't mind the addition! :)
