### PR TITLE
Slightly faster window resizing

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -124,6 +124,12 @@ namespace Tooth {
 				start_hidden = false;
 				return;
 			}
+			settings.delay ();
+		}
+
+		protected override void shutdown () {
+			settings.apply ();
+			base.shutdown ();
 		}
 
 		public override void open (File[] files, string hint) {


### PR DESCRIPTION
Small fix. Currently, the window when being resized looks a little laggy, this MR makes it look faster. 

To implement this, the settings service saves its changes until the application is closed, instead of saving them when any property is changed, which makes in general the tweaking of settings in the preferences window slightly faster too.