### PR TITLE
main: Use the over transition for the leaflet

### DIFF
--- a/data/ui/dialogs/main.ui
+++ b/data/ui/dialogs/main.ui
@@ -22,7 +22,7 @@
         <!-- </child> -->
         <child type="content">
           <object class="AdwLeaflet" id="leaflet">
-            <property name="transition_type">slide</property>
+            <property name="transition_type">over</property>
             <property name="can-navigate-back">1</property>
             <property name="can-unfold">0</property>
             <property name="homogeneous">0</property>


### PR DESCRIPTION
The slide transition reveals the lack of separator between the pages and the headerbar border, which looks odd. The over transition fixes that. Also the slide transition doesn't denote a back gesture as well as the over transition.