### PR TITLE
Fix header text wrapping in sidebar

### DIFF
--- a/data/ui/views/sidebar/view.ui
+++ b/data/ui/views/sidebar/view.ui
@@ -3,6 +3,7 @@
   <template class="ToothViewsSidebar" parent="GtkBox">
     <property name="width_request">300</property>
     <property name="orientation">vertical</property>
+    <property name="hexpand">false</property>
 
     <child>
       <object class="AdwHeaderBar">
@@ -62,8 +63,9 @@
                         <object class="GtkBox">
                           <property name="orientation">vertical</property>
                           <property name="valign">center</property>
+                          <property name="hexpand">true</property>
+                          <property name="spacing">6</property>
                           <child>
-                            <!-- FIXME: Wrapping -->
                             <!-- <object class="ToothWidgetsEmojiLabel" id="title"> -->
                             <object class="GtkLabel" id="title">
                               <property name="label">Account Name</property>

--- a/data/ui/views/sidebar/view.ui
+++ b/data/ui/views/sidebar/view.ui
@@ -66,6 +66,7 @@
                           <property name="hexpand">true</property>
                           <property name="spacing">6</property>
                           <child>
+                            <!-- FIXME: Wrapping -->
                             <!-- <object class="ToothWidgetsEmojiLabel" id="title"> -->
                             <object class="GtkLabel" id="title">
                               <property name="label">Account Name</property>


### PR DESCRIPTION
Sometimes the text in sidebar header is wrapped even if there is room for the text. This PR expands the text box and adds a slight vertical padding to make the layout a bit more neat.

| Before  | After |
| ------------- | ------------- |
| ![Screenshot from 2023-01-07 14-20-48](https://user-images.githubusercontent.com/20158357/211145993-66582840-6b1e-48b6-b070-5d13421a5611.png) | ![Screenshot from 2023-01-07 14-20-31](https://user-images.githubusercontent.com/20158357/211146012-67fa61f4-f129-4993-a09a-99d4eeea0f91.png) |