### PR TITLE
Minor visual tweaks

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -8,6 +8,9 @@
 .font-bold {
   font-weight: bold;
 }
+.no-shadow {
+	box-shadow: none;
+}
 
 .attachment, .attachment button, flowboxchild {
 	padding:0px;
@@ -96,7 +99,7 @@
 	background: @theme_base_color;
 }
 .large .header-image {
-  border-radius:6px 6px 0 0;
+  border-radius: 12px 12px 0 0;
 }
 
 /* Status action icons */
@@ -135,6 +138,8 @@
 
 .ttl-profile-stat-button, .small .ttl-profile-stat-button:first-child, .small .ttl-profile-stat-button:last-child {
 	border-radius: 0px;
+	padding: 8px 12px;
+	min-height: 32px;
 }
 
 .ttl-profile-stat-button:first-child {

--- a/data/ui/views/profile_header.ui
+++ b/data/ui/views/profile_header.ui
@@ -15,6 +15,7 @@
         <child>
 
 <object class="GtkListBoxRow">
+  <property name="activatable">false</property>
   <child>
 
   <object class="GtkGrid">

--- a/data/ui/widgets/status.ui
+++ b/data/ui/widgets/status.ui
@@ -79,7 +79,7 @@
             <child>
               <object class="GtkBox" id="indicators">
                 <property name="halign">end</property>
-                <property name="valign">start</property>
+                <property name="valign">center</property>
                 <property name="margin_start">6</property>
                 <property name="spacing">6</property>
                 <child>

--- a/data/ui/widgets/votebox.ui
+++ b/data/ui/widgets/votebox.ui
@@ -11,6 +11,8 @@
         </child>
         <style>
           <class name="boxed-list"/>
+          <class name="frame"/>
+          <class name="no-shadow"/>
         </style>
       </object>
     </child>

--- a/src/Utils/DateTime.vala
+++ b/src/Utils/DateTime.vala
@@ -20,7 +20,7 @@ public class Tooth.DateTime {
 			var days = delta / TimeSpan.DAY;
 			return _(@"$(days)d left");
 		} else {
-			return date.format (_("expires on %b %e, %Y"));
+			return date.format (_("expires on %b %-e, %Y"));
 		}
 	}
 
@@ -29,7 +29,7 @@ public class Tooth.DateTime {
 		var now = new GLib.DateTime.now_local ();
 		var delta = now.difference (date);
 		if (delta < 0)
-			return date.format (_("expires on %b %e, %Y %H:%m"));
+			return date.format (_("expires on %b %-e, %Y %H:%m"));
 		else if (delta <= TimeSpan.MINUTE)
 			return _("expired on just now");
 		else if (delta < TimeSpan.HOUR) {
@@ -44,10 +44,10 @@ public class Tooth.DateTime {
 			return _("expired yesterday");
 		}
 		else if (date.get_year () == now.get_year ()) {
-			return date.format (_("expired on %b %e"));
+			return date.format (_("expired on %b %-e"));
 		}
 		else {
-			return date.format (_("expired on %b %e, %Y"));
+			return date.format (_("expired on %b %-e, %Y"));
 		}
 	}
 
@@ -56,7 +56,7 @@ public class Tooth.DateTime {
 		var now = new GLib.DateTime.now_local ();
 		var delta = now.difference (date);
 		if (delta < 0)
-			return date.format (_("%b %e, %Y %H:%m"));
+			return date.format (_("%b %-e, %Y %H:%m"));
 		else if (delta <= TimeSpan.MINUTE)
 			return _("Just now");
 		else if (delta < TimeSpan.HOUR) {
@@ -71,10 +71,10 @@ public class Tooth.DateTime {
 			return _("Yesterday");
 		}
 		else if (date.get_year () == now.get_year ()) {
-			return date.format (_("%b %e"));
+			return date.format (_("%b %-e"));
 		}
 		else {
-			return date.format (_("%b %e, %Y"));
+			return date.format (_("%b %-e, %Y"));
 		}
 	}
 

--- a/src/Views/Profile.vala
+++ b/src/Views/Profile.vala
@@ -87,7 +87,7 @@ public class Tooth.Views.Profile : Views.Timeline {
 
 	protected void build_profile_stats(ListBox info) {
 		var row = new Gtk.ListBoxRow ();
-		var box = new Box (Orientation.HORIZONTAL, 6) {
+		var box = new Box (Orientation.HORIZONTAL, 0) {
 			homogeneous = true
 		};
 

--- a/src/Widgets/VoteBox.vala
+++ b/src/Widgets/VoteBox.vala
@@ -87,8 +87,8 @@ public class Tooth.Widgets.VoteBox: Box {
                     }
                 }
 
-                row.title = "%.1f%%".printf(percentage);
-                row.subtitle = p.title;
+                row.subtitle = "%.1f%%".printf(percentage);
+                row.title = p.title;
                 pollBox.append(row);
             }
             else{


### PR DESCRIPTION
This PR fixes minor inconsistencies in the app's layout to improve its overall appearance.

**Profile view:**
- Increase the cover image's border radius
- Increase the stat row's height
- Disable activation of the note row

**Status widget:**
- Center the indicator box vertically

**Poll widget:**
- Make the widget flatter
- Move percentage to the row subtitle

**DateTime utils:**
- Prevent `humanize()` and its derivatives from producing double spaces (`Jan  6` -> `Jan 6`)