### PR TITLE
Refactor Add Account dialog

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -9,6 +9,10 @@
   font-weight: bold;
 }
 
+headerbar.flat .title {
+	opacity: 0;
+}
+
 .attachment, .attachment button, flowboxchild {
 	padding:0px;
 	margin:0px;

--- a/data/style.css
+++ b/data/style.css
@@ -9,7 +9,7 @@
   font-weight: bold;
 }
 
-headerbar.flat .title {
+headerbar.flat.no-title .title {
 	opacity: 0;
 }
 

--- a/data/ui/dialogs/new_account.ui
+++ b/data/ui/dialogs/new_account.ui
@@ -67,7 +67,7 @@
                               <object class="AdwPreferencesGroup">
                                 <child>
                                   <object class="AdwEntryRow" id="instance_entry">
-                                    <property name="title" translatable="false">https://</property>
+                                    <property name="title" translatable="true">Server URL</property>
                                     <signal name="entry_activated" handler="on_next_clicked" swapped="no"/>
                                     <signal name="changed" handler="clear_errors" swapped="no"/>
                                   </object>

--- a/data/ui/dialogs/new_account.ui
+++ b/data/ui/dialogs/new_account.ui
@@ -8,14 +8,19 @@
     <property name="title" translatable="yes">Add Account</property>
     <child>
       <object class="AdwLeaflet" id="deck">
-        <property name="can_navigate_back">1</property>
         <property name="can_unfold">0</property>
+        <property name="transition_type">slide</property>
         <signal name="notify::visible_child" handler="on_visible_child_notify" swapped="no"/>
         <child>
           <object class="GtkBox" id="instance_step">
             <property name="orientation">vertical</property>
             <child>
               <object class="AdwHeaderBar">
+                <property name="show-end-title-buttons">false</property>
+                <property name="show-start-title-buttons">false</property>
+                <style>
+                    <class name="flat"/>
+                </style>
                 <child>
                   <object class="GtkButton">
                     <property name="label" translatable="yes">Cancel</property>
@@ -39,7 +44,10 @@
               <object class="AdwStatusPage">
                 <property name="vexpand">1</property>
                 <property name="icon_name">tooth-network-server-symbolic</property>
-                <property name="title" translatable="yes">What is Your Instance?</property>
+                <property name="title" translatable="yes">What is your Instance?</property>
+                <style>
+                    <class name="compact"/>
+                </style>
                 <child>
                   <object class="AdwClamp">
                     <property name="maximum-size">400</property>
@@ -103,6 +111,11 @@
             <property name="orientation">vertical</property>
             <child>
               <object class="AdwHeaderBar">
+                <property name="show-end-title-buttons">false</property>
+                <property name="show-start-title-buttons">false</property>
+                <style>
+                    <class name="flat"/>
+                </style>
                 <child>
                   <object class="GtkButton">
                     <property name="label" translatable="yes">Previous</property>
@@ -126,7 +139,10 @@
               <object class="AdwStatusPage">
                 <property name="vexpand">1</property>
                 <property name="icon_name">tooth-key-password-symbolic</property>
-                <property name="title" translatable="yes">Enter Authorization Code</property>
+                <property name="title" translatable="yes">Enter authorization Code</property>
+                <style>
+                    <class name="compact"/>
+                </style>
                 <child>
                   <object class="AdwClamp">
                     <property name="maximum-size">400</property>
@@ -176,6 +192,11 @@
             <property name="orientation">vertical</property>
             <child>
               <object class="AdwHeaderBar">
+                <property name="show-end-title-buttons">false</property>
+                <property name="show-start-title-buttons">false</property>
+                <style>
+                    <class name="flat"/>
+                </style>
                 <child type="end">
                   <object class="GtkButton">
                     <property name="receives_default">1</property>
@@ -194,6 +215,9 @@
                 <property name="vexpand">1</property>
                 <property name="icon_name">tooth-check-round-outline-symbolic</property>
                 <property name="title">Welcome!</property>
+                <style>
+                    <class name="compact"/>
+                </style>
               </object>
             </child>
           </object>

--- a/data/ui/dialogs/new_account.ui
+++ b/data/ui/dialogs/new_account.ui
@@ -103,6 +103,7 @@
                 <property name="show-start-title-buttons">false</property>
                 <style>
                     <class name="flat"/>
+                    <class name="no-title"/>
                 </style>
                 <child>
                   <object class="GtkButton">
@@ -183,6 +184,7 @@
                 <property name="show-start-title-buttons">false</property>
                 <style>
                     <class name="flat"/>
+                    <class name="no-title"/>
                 </style>
                 <child type="end">
                   <object class="GtkButton">

--- a/data/ui/dialogs/new_account.ui
+++ b/data/ui/dialogs/new_account.ui
@@ -68,6 +68,7 @@
                                 <child>
                                   <object class="AdwEntryRow" id="instance_entry">
                                     <property name="title" translatable="true">Server URL</property>
+                                    <property name="input_purpose">url</property>
                                     <signal name="entry_activated" handler="on_next_clicked" swapped="no"/>
                                     <signal name="changed" handler="clear_errors" swapped="no"/>
                                   </object>

--- a/data/ui/dialogs/new_account.ui
+++ b/data/ui/dialogs/new_account.ui
@@ -20,6 +20,7 @@
                 <property name="show-start-title-buttons">false</property>
                 <style>
                     <class name="flat"/>
+                    <class name="no-title"/>
                 </style>
                 <child>
                   <object class="GtkButton">

--- a/data/ui/dialogs/new_account.ui
+++ b/data/ui/dialogs/new_account.ui
@@ -44,7 +44,8 @@
               <object class="AdwStatusPage">
                 <property name="vexpand">1</property>
                 <property name="icon_name">tooth-network-server-symbolic</property>
-                <property name="title" translatable="yes">What is your Instance?</property>
+                <property name="title" translatable="yes">What is your Server?</property>
+                <property name="description" translatable="yes">If you don&apos;t have one yet, you can register &lt;a href=&quot;https://joinmastodon.org/servers&quot;&gt;here&lt;/a&gt;.</property>
                 <style>
                     <class name="compact"/>
                 </style>
@@ -61,24 +62,17 @@
                             <property name="orientation">vertical</property>
                             <property name="spacing">6</property>
                             <child>
-                              <object class="GtkBox">
+
+                              <object class="AdwPreferencesGroup">
                                 <child>
-                                  <object class="GtkButton">
-                                    <property name="label">https://</property>
-                                    <property name="sensitive">0</property>
-                                    <property name="receives_default">1</property>
+                                  <object class="AdwEntryRow" id="instance_entry">
+                                    <property name="title" translatable="false">https://</property>
+                                    <signal name="entry_activated" handler="on_next_clicked" swapped="no"/>
+                                    <signal name="changed" handler="clear_errors" swapped="no"/>
                                   </object>
                                 </child>
-                                <child>
-                                  <object class="GtkEntry" id="instance_entry">
-                                    <property name="hexpand">1</property>
-                                    <signal name="activate" handler="on_next_clicked" swapped="no"/>
-                                  </object>
-                                </child>
-                                <style>
-                                  <class name="linked"/>
-                                </style>
                               </object>
+
                             </child>
                             <child>
                               <object class="GtkLabel" id="instance_entry_error">
@@ -89,13 +83,6 @@
                                 </style>
                               </object>
                             </child>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="label" translatable="yes">&lt;a href=&quot;https://joinmastodon.org/&quot;&gt;Don&apos;t have one yet?&lt;/a&gt;</property>
-                            <property name="use_markup">1</property>
-                            <property name="xalign">1</property>
                           </object>
                         </child>
                       </object>
@@ -118,7 +105,7 @@
                 </style>
                 <child>
                   <object class="GtkButton">
-                    <property name="label" translatable="yes">Previous</property>
+                    <property name="label" translatable="yes">Back</property>
                     <signal name="clicked" handler="on_back_clicked" swapped="no"/>
                   </object>
                 </child>
@@ -136,10 +123,10 @@
               </object>
             </child>
             <child>
-              <object class="AdwStatusPage">
+              <object class="AdwStatusPage" id="auth_page">
                 <property name="vexpand">1</property>
                 <property name="icon_name">tooth-key-password-symbolic</property>
-                <property name="title" translatable="yes">Enter authorization Code</property>
+                <property name="title" translatable="yes">Confirm Authorization</property>
                 <style>
                     <class name="compact"/>
                 </style>
@@ -156,8 +143,15 @@
                             <property name="orientation">vertical</property>
                             <property name="spacing">6</property>
                             <child>
-                              <object class="GtkEntry" id="code_entry">
-                                <signal name="activate" handler="on_next_clicked" swapped="no"/>
+                              <object class="AdwPreferencesGroup">
+                                <property name="visible" bind-source="ToothDialogsNewAccount" bind-property="use_auto_auth" bind-flags="sync-create|invert-boolean"/>"
+                                <child>
+                                  <object class="AdwEntryRow" id="code_entry">
+                                    <property name="title" translatable="true">Authorization Code</property>
+                                    <signal name="entry_activated" handler="on_next_clicked" swapped="no"/>
+                                    <signal name="changed" handler="clear_errors" swapped="no"/>
+                                  </object>
+                                </child>
                               </object>
                             </child>
                             <child>
@@ -169,14 +163,6 @@
                                 </style>
                               </object>
                             </child>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="code_label">
-                            <property name="label" translatable="yes">Didn't work? &lt;a href=&quot;tooth://manual_auth&quot;&gt;Try manual authorization.&lt;/a&gt;</property>
-                            <property name="use_markup">1</property>
-                            <property name="xalign">1</property>
-                            <signal name="activate-link" handler="on_activate_code_label_link" swapped="no"/>
                           </object>
                         </child>
                       </object>
@@ -214,7 +200,8 @@
               <object class="AdwStatusPage" id="done_page">
                 <property name="vexpand">1</property>
                 <property name="icon_name">tooth-check-round-outline-symbolic</property>
-                <property name="title">Welcome!</property>
+                <property name="title">Hello!</property>
+                <property name="description" translatable="true">Your account is connected and ready to use.</property>
                 <style>
                     <class name="compact"/>
                 </style>

--- a/src/Dialogs/NewAccount.vala
+++ b/src/Dialogs/NewAccount.vala
@@ -31,6 +31,12 @@ public class Tooth.Dialogs.NewAccount: Adw.Window {
 		Object (transient_for: app.main_window);
 		app.add_account_window = this;
 		app.add_window (this);
+
+		bind_property("use-auto-auth", auth_page, "description", BindingFlags.SYNC_CREATE, (b, src, ref target) => {
+			target.set_string (src.get_boolean () ? AUTO_AUTH_DESCRIPTION : CODE_AUTH_DESCRIPTION);
+			return true;
+		});
+
 		reset ();
 		present ();
 	}
@@ -116,7 +122,6 @@ public class Tooth.Dialogs.NewAccount: Adw.Window {
 		account.client_secret = root.get_string_member ("client_secret");
 		message ("OK: Instance registered client");
 
-		auth_page.description = use_auto_auth ? AUTO_AUTH_DESCRIPTION : CODE_AUTH_DESCRIPTION;
 		deck.visible_child = code_step;
 		open_confirmation_page ();
 	}

--- a/src/Services/Network/Network.vala
+++ b/src/Services/Network/Network.vala
@@ -59,8 +59,7 @@ public class Tooth.Network : GLib.Object {
 			else if (status == Soup.Status.CANCELLED)
 				debug ("Message is cancelled. Ignoring callback invocation.");
 			else
-				critical (@"Should be ecb: $status $(msg.reason_phrase)");
-				//  ecb ((int32) status, msg.reason_phrase);
+				ecb ((int32) status, msg.reason_phrase);
 		});
 	}
 

--- a/src/Services/Network/Request.vala
+++ b/src/Services/Network/Request.vala
@@ -101,7 +101,7 @@ public class Tooth.Request : Soup.Message {
 		if (form_data != null)
 			form_data.to_message(request_headers, request_body);
 
-		if (account != null) {
+		if (account != null && account.access_token != null) {
 			request_headers.append ("Authorization", @"Bearer $(account.access_token)");
 		}
 


### PR DESCRIPTION
This PR makes the following changes to the dialog:
- Flatten the header bar
- Replace vanilla `Gtk.Entry` widgets with their `Adw.EntryRow` variants
- Change wording on some screens
- Hide the auth token entry unless manual authorization is explicitly requested by the user
- Fix the Network service so that error messages are properly passed to the dialog


| Before  | After |
| ------------- | ------------- |
| ![Screenshot from 2023-01-09 22-24-04](https://user-images.githubusercontent.com/20158357/211380508-61e6ef86-2e03-4f5f-9d2f-38d6ba86ae81.png)  | ![Screenshot from 2023-01-09 22-23-52](https://user-images.githubusercontent.com/20158357/211380552-cd64de27-2028-4b3d-b629-4079dbf4d9c0.png)  |
| | ![Screenshot from 2023-01-09 22-38-44](https://user-images.githubusercontent.com/20158357/211383123-9589d00a-7953-4874-ae47-b49790a9a34c.png) |
|  ![Screenshot from 2023-01-09 22-40-20](https://user-images.githubusercontent.com/20158357/211383326-acfe5dfd-30f7-4c9e-a0a5-8df15d99b680.png)  |  ![Screenshot from 2023-01-09 22-42-21](https://user-images.githubusercontent.com/20158357/211383661-4f562a2e-13da-4c05-a25d-a7c4a8184631.png)  |
| ![Screenshot from 2023-01-09 22-40-29](https://user-images.githubusercontent.com/20158357/211383353-dbd43dcd-b160-4ec9-bba9-ba220e8a56f9.png) | ![Screenshot from 2023-01-09 22-38-54](https://user-images.githubusercontent.com/20158357/211383151-36c2c0a6-c770-4e0a-915b-40d2ab826471.png) |










Feedback and testing appreciated 😄 
