### PR TITLE
Add meson profiles

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       options: --privileged
     steps:
     - uses: actions/checkout@v3
-    - uses: flatpak/flatpak-github-actions/flatpak-builder@master
+    - uses: flatpak/flatpak-github-actions/flatpak-builder@v5
       with:
-        bundle: "dev.geopjr.tooth.flatpak"
-        manifest-path: "dev.geopjr.tooth.json"
+        bundle: "dev.geopjr.tooth.Devel.flatpak"
+        manifest-path: "dev.geopjr.tooth.Devel.json"

--- a/data/meson.build
+++ b/data/meson.build
@@ -2,8 +2,13 @@ icons_dir = join_paths(get_option('datadir'), 'icons', 'hicolor')
 scalable_dir = join_paths(icons_dir, 'scalable', 'apps')
 symbolic_dir = join_paths(icons_dir, 'symbolic', 'apps')
 
+icon = 'color.svg'
+if get_option('profile') == 'development'
+  icon = 'color-nightly.svg'
+endif
+
 install_data(
-    join_paths('icons', 'color.svg'),
+    join_paths('icons', icon),
     install_dir: scalable_dir,
     rename: meson.project_name() + '.svg',
 )

--- a/data/meson.build
+++ b/data/meson.build
@@ -3,7 +3,7 @@ scalable_dir = join_paths(icons_dir, 'scalable', 'apps')
 symbolic_dir = join_paths(icons_dir, 'symbolic', 'apps')
 
 icon = 'color.svg'
-if get_option('profile') == 'development'
+if get_option('devel')
   icon = 'color-nightly.svg'
 endif
 

--- a/dev.geopjr.tooth.Devel.json
+++ b/dev.geopjr.tooth.Devel.json
@@ -37,7 +37,7 @@
             "builddir": true,
             "buildsystem": "meson",
             "config-opts" : [
-                "-Dprofile=development"
+                "-Ddevel=true"
             ],
             "sources": [
                 {

--- a/dev.geopjr.tooth.Devel.json
+++ b/dev.geopjr.tooth.Devel.json
@@ -1,0 +1,50 @@
+{
+    "app-id": "dev.geopjr.tooth",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "43",
+    "sdk": "org.gnome.Sdk",
+    "sdk-extensions" : ["org.freedesktop.Sdk.Extension.vala"],
+    "build-options" : {
+        "prepend-path" : "/usr/lib/sdk/vala/bin/",
+        "prepend-ld-library-path" : "/usr/lib/sdk/vala/lib"
+    },
+    "command": "dev.geopjr.tooth",
+    "finish-args": [
+        "--device=dri",
+        "--share=ipc",
+        "--share=network",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--talk-name=org.gtk.vfs",
+        "--talk-name=org.gtk.vfs.*",
+        "--filesystem=xdg-run/gvfsd"
+    ],
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/man",
+        "/share/doc",
+        "/share/gtk-doc",
+        "/share/man",
+        "/share/pkgconfig",
+        "/share/vala",
+        "*.la",
+        "*.a"
+    ],
+    "modules": [
+        {
+            "name": "tooth",
+            "builddir": true,
+            "buildsystem": "meson",
+            "config-opts" : [
+                "-Dprofile=development"
+            ],
+            "sources": [
+                {
+                    "type": "dir",
+                    "path": "."
+                }
+            ]
+        }
+    ]
+}

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,7 @@
 
 set -e
 meson setup build --prefix=/usr
+meson configure build -Dprofile=development
 cd build
 ninja
 sudo ninja install

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 set -e
 meson setup build --prefix=/usr
-meson configure build -Dprofile=development
+meson configure build -Ddevel=true
 cd build
 ninja
 sudo ninja install

--- a/meson.build
+++ b/meson.build
@@ -35,8 +35,8 @@ config.set(
 if profile == 'development'
   git = find_program('git')
   if git.found()
-    branch = run_command('git', 'branch', '--show-current').stdout().strip()
-    revision = run_command('git', 'rev-parse', '--short', 'HEAD').stdout().strip()
+    branch = run_command('git', 'branch', '--show-current', check: true).stdout().strip()
+    revision = run_command('git', 'rev-parse', '--short', 'HEAD', check: true).stdout().strip()
     version = '@0@-@1@'.format(branch, revision)
     config.set('VERSION', version)
   endif

--- a/meson.build
+++ b/meson.build
@@ -16,14 +16,14 @@ add_global_arguments(
     language: 'c',
 )
 
-profile = get_option('profile')
+devel = get_option('devel')
 config = configuration_data()
 config.set('EXEC_NAME', meson.project_name())
 config.set('GETTEXT_PACKAGE', meson.project_name())
 config.set('RESOURCES', '/' + '/'.join(meson.project_name().split('.')) + '/')
 config.set('VERSION', meson.project_version())
 config.set('PREFIX', get_option('prefix'))
-config.set('PROFILE', profile)
+config.set('PROFILE', devel ? 'development' : 'production')
 config.set('NAME', 'Tooth')
 config.set('WEBSITE', 'https://github.com/GeopJr/tooth')
 config.set('SUPPORT_WEBSITE', 'https://github.com/GeopJr/tooth/issues')
@@ -32,7 +32,7 @@ config.set(
     '© 2022 bleak_grey\n© 2022 Evangelos \"GeopJr\" Paterakis',
 )
 
-if profile == 'development'
+if devel
   git = find_program('git')
   if git.found()
     branch = run_command('git', 'branch', '--show-current', check: true).stdout().strip()

--- a/meson.build
+++ b/meson.build
@@ -16,19 +16,29 @@ add_global_arguments(
     language: 'c',
 )
 
+profile = get_option('profile')
 config = configuration_data()
 config.set('EXEC_NAME', meson.project_name())
 config.set('GETTEXT_PACKAGE', meson.project_name())
 config.set('RESOURCES', '/' + '/'.join(meson.project_name().split('.')) + '/')
 config.set('VERSION', meson.project_version())
 config.set('PREFIX', get_option('prefix'))
+config.set('PROFILE', profile)
 config.set('NAME', 'Tooth')
 config.set('WEBSITE', 'https://github.com/GeopJr/tooth')
 config.set('SUPPORT_WEBSITE', 'https://github.com/GeopJr/tooth/issues')
 config.set(
     'COPYRIGHT',
-    '© 2018-2021 bleak_grey\n© 2022 Evangelos \"GeopJr\" Paterakis',
+    '© 2022 bleak_grey\n© 2022 Evangelos \"GeopJr\" Paterakis',
 )
+
+if profile == 'development'
+  find_program('git')
+  branch = run_command('git', 'branch', '--show-current').stdout().strip()
+  revision = run_command('git', 'rev-parse', '--short', 'HEAD').stdout().strip()
+  version = '@0@-@1@'.format(branch, revision)
+  config.set('VERSION', version)
+endif
 
 gnome = import('gnome')
 i18n = import('i18n')

--- a/meson.build
+++ b/meson.build
@@ -33,11 +33,13 @@ config.set(
 )
 
 if profile == 'development'
-  find_program('git')
-  branch = run_command('git', 'branch', '--show-current').stdout().strip()
-  revision = run_command('git', 'rev-parse', '--short', 'HEAD').stdout().strip()
-  version = '@0@-@1@'.format(branch, revision)
-  config.set('VERSION', version)
+  git = find_program('git')
+  if git.found()
+    branch = run_command('git', 'branch', '--show-current').stdout().strip()
+    revision = run_command('git', 'rev-parse', '--short', 'HEAD').stdout().strip()
+    version = '@0@-@1@'.format(branch, revision)
+    config.set('VERSION', version)
+  endif
 endif
 
 gnome = import('gnome')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,1 @@
-option('profile', type: 'combo', choices: ['production', 'development'], value: 'production')
+option('devel', type: 'boolean', value: false)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('profile', type: 'combo', choices: ['production', 'development'], value: 'production')

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -200,9 +200,9 @@ namespace Tooth {
 			refresh ();
 		}
 
-		string troubleshooting = "flatpak: %s\nversion: %s\ngtk: %u.%u.%u (%d.%d.%d)\nlibadwaita: %u.%u.%u (%d.%d.%d)\n".printf(
+		string troubleshooting = "flatpak: %s\nversion: %s (%s)\ngtk: %u.%u.%u (%d.%d.%d)\nlibadwaita: %u.%u.%u (%d.%d.%d)\n".printf(
 				(GLib.Environment.get_variable("FLATPAK_ID") != null || GLib.File.new_for_path("/.flatpak-info").query_exists()).to_string(),
-				Build.VERSION,
+				Build.VERSION, Build.PROFILE,
 				Gtk.get_major_version(), Gtk.get_minor_version(), Gtk.get_micro_version(),
 				Gtk.MAJOR_VERSION, Gtk.MINOR_VERSION, Gtk.MICRO_VERSION,
 				Adw.get_major_version(), Adw.get_minor_version(), Adw.get_micro_version(),

--- a/src/Build.vala.in
+++ b/src/Build.vala.in
@@ -8,6 +8,7 @@ public class Build {
 	public const string SUPPORT_WEBSITE = "@SUPPORT_WEBSITE@";
 	public const string COPYRIGHT = "@COPYRIGHT@";
 	public const string PREFIX = "@PREFIX@";
+	public const string PROFILE = "@PROFILE@";
 
 	public static string SYSTEM_INFO;
 
@@ -23,6 +24,7 @@ public class Build {
 		SYSTEM_INFO = @"$NAME $VERSION";
 		SYSTEM_INFO += @"\nRunning on: $os_name $os_ver";
 		SYSTEM_INFO += @"\nBuild prefix: \"$PREFIX\"";
+		SYSTEM_INFO += @"\nBuild profile: \"$PROFILE\"";
 
 		var lines = SYSTEM_INFO.split ("\n");
 		foreach (unowned string line in lines) {

--- a/src/Dialogs/MainWindow.vala
+++ b/src/Dialogs/MainWindow.vala
@@ -32,6 +32,10 @@ public class Tooth.Dialogs.MainWindow: Adw.ApplicationWindow, Saveable {
 		);
 		sidebar.set_sidebar_selected_item(0);
 		open_view (new Views.Main ());
+
+		if (Build.PROFILE == "development") {
+			this.add_css_class ("devel");
+		}
 	}
 
 	public Views.Base open_view (Views.Base view) {


### PR DESCRIPTION
This PR adds a `profile` option to the meson configuration. If is set to `development` during compilation, the app will:
- Add `.devel` class to the main window
- Use alternative nightly icon
- Modify About dialog to display branch name and revision hash instead of a version (which makes sense in production builds only)

Additionally, a development Flatpak manifest is added with [Vala SDK](https://github.com/flathub/org.freedesktop.Sdk.Extension.vala) enabled for syntax highlighting in GNOME Builder.

![Screenshot from 2023-01-12 11-56-42](https://user-images.githubusercontent.com/20158357/212036483-0be4b185-21b8-4576-b0dc-aed2d13ff078.png)
